### PR TITLE
refactor: serve static files from public folder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="styles.css">
   </head>
   <body>
     <div class="shell">

--- a/server.js
+++ b/server.js
@@ -20,14 +20,14 @@ if (!API_KEY) {
 }
 
 // ✅ Correctly resolve to the project’s /public folder
-const PUBLIC_DIR = path.join(__dirname, 'public');
+const PUBLIC_DIR = path.resolve(__dirname, 'public');
 
 // Serve static frontend files
 app.use(express.static(PUBLIC_DIR));
 
 // Root route → serve index.html
 app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'));
+  res.sendFile(path.join(PUBLIC_DIR, 'index.html'));
 });
 
 // Helper: clamp numbers


### PR DESCRIPTION
## Summary
- move `index.html` into `public` and serve from there
- resolve public directory with `path.resolve(__dirname, 'public')`
- update stylesheet link to be relative to `/public`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(fails: Cannot find package 'express' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68a468a5fa44833189d9f13495e14744